### PR TITLE
feat(modal): add read-only views for approved/rejected status

### DIFF
--- a/client/src/app/auditoria/page.tsx
+++ b/client/src/app/auditoria/page.tsx
@@ -55,6 +55,7 @@ const minhasAuditorias: (RowAuditoriaProps & { acao: string; })[] = [
       { id: 'doc3_3', nome: 'Comprovante_Coleta.pdf', tipo: 'PDF', dataEnvio: '2025-06-08T11:00:00Z', url: '#' },
     ],
     acao: "Doação de Roupas",
+    motivoReprovacao: 'A nota fiscal apresentada não corresponde aos itens listados na declaração de doação. Por favor, envie o documento correto para uma nova análise.'
   },
 ];
 
@@ -188,7 +189,7 @@ export default function AuditoriaPage() {
                 <span className="font-sans text-[12px] font-semibold text-[#6A7282]">STATUS</span>
             </div>
 
-            <div className="w-[90px]">
+            <div className="w-[125px]">
                 <span className="font-sans text-[12px] font-semibold text-[#6A7282]">AÇÃO</span>
             </div>
           </div>

--- a/client/src/components/modal-revisao/index.tsx
+++ b/client/src/components/modal-revisao/index.tsx
@@ -1,9 +1,10 @@
 import { Dialog, Transition } from '@headlessui/react';
 import { Fragment, useState } from 'react';
 import { format } from 'date-fns';
-import { X, File, Download } from 'lucide-react'; 
+import { X, File, Download, CheckCircle2, XCircle } from 'lucide-react'; 
 import { type RowAuditoriaProps } from '@/components/row-auditoria';
 import Button from '@/components/button';
+import Chip from '@/components/chip-status'
 
 interface ModalRevisaoProps {
   isOpen: boolean;
@@ -13,10 +14,9 @@ interface ModalRevisaoProps {
 
 export default function ModalRevisao({ isOpen, onClose, auditoria }: ModalRevisaoProps) {
   const [isReproving, setIsReproving] = useState(false);
-
-  if (!auditoria) {
-    return null;
-  }
+  
+  if (!auditoria) return null;
+  
   const formattedDate = format(new Date(auditoria.dataDoacao), 'dd/MM/yyyy');
   
   const handleClose = () => {
@@ -24,36 +24,73 @@ export default function ModalRevisao({ isOpen, onClose, auditoria }: ModalRevisa
     onClose();
   };
   
+  // Renderiza o conteúdo principal (detalhes e documentos)
+  const renderDetailsAndDocuments = () => (
+    <>
+      <div className='flex gap-3 p-4 bg-[#F9FAFB] rounded-[6px]'>
+        <div className='flex flex-col gap-1.5 items-start w-1/2'>
+          <h3 className='font-sans text-[14px] font-semibold text-[#101828]'>Detalhes da Doação</h3>
+          <div className='text-left'>
+            <p className='font-sans text-[14px] font-normal text-[#0A0A0A]'><span className="font-semibold">Empresa:</span> {auditoria.nomeEmpresa}</p>
+            <p className='font-sans text-[14px] font-normal text-[#0A0A0A]'><span className="font-semibold">Email:</span> {auditoria.emailEmpresa}</p>
+            <p className='font-sans text-[14px] font-normal text-[#0A0A0A]'><span className="font-semibold">ONG Beneficiada:</span> {auditoria.nomeONG}</p>
+          </div>
+        </div>
+        <div className='flex flex-col gap-1.5 items-start w-1/2'>
+          <h3 className='font-sans text-[14px] font-semibold text-[#101828]'>Informações da Doação</h3>
+          <div className='text-left'>
+            <p className='font-sans text-[14px] font-normal text-[#0A0A0A]'><span className="font-semibold">Ação:</span> {auditoria.acao || 'Não informado'}</p>
+            <p className='font-sans text-[14px] font-normal text-[#0A0A0A]'><span className="font-semibold">Tipo:</span> {auditoria.tipoDoacao}</p>
+            <p className='font-sans text-[14px] font-normal text-[#0A0A0A]'><span className="font-semibold">Valor/Quantidade:</span> {auditoria.valorDoacao}</p>
+          </div>
+        </div>
+      </div>
+      <div className='flex flex-col gap-4 flex-1 min-h-0'>
+        <h4 className='font-sans text-[16px] font-semibold text-[#101828]'>Documentos Anexados ({auditoria.documentos.length})</h4>
+        <div className="flex flex-col gap-2.5 h-full overflow-y-auto pr-4">
+          {auditoria.documentos.map((doc) => (
+            <div key={doc.id} className="flex justify-between items-center p-4 border border-[#E5E7EB] rounded-[8px]"> 
+              <div className="flex items-center gap-3 text-left"> 
+                <div className='flex-shrink-0 flex items-center justify-center w-[34px] h-[34px] bg-[#EFF6FF] rounded-[4px]'><File size={20} className='text-[#1474FF]' /></div> 
+                <div>
+                  <p className="font-sans text-[#101828] text-[14px] font-semibold">{doc.nome}</p>
+                  <p className="font-sans text-[#6A7282] text-[12px] font-normal">
+                    {doc.tipo} • Enviado em {format(new Date(doc.dataEnvio), 'dd/MM/yyyy')}
+                  </p>
+                </div>
+              </div>
+              <a href={doc.url} download={doc.nome} target="_blank" rel="noopener noreferrer" className="inline-flex items-center justify-center px-3 py-1.5 rounded-md font-semibold text-xs transition-colors bg-white text-gray-800 border border-gray-300 hover:bg-gray-100 flex-shrink-0">
+                <Download size={14} className="mr-2" /> <span>Baixar</span>
+              </a>
+            </div>
+          ))}
+        </div>
+      </div>
+    </>
+  );
+
   return (
     <Transition appear show={isOpen}>
       <Dialog as="div" className="relative z-10" onClose={handleClose}>
         <div className="fixed inset-0 bg-black/30" />
         <div className="fixed inset-0 overflow-y-auto">
           <div className="flex min-h-full items-center justify-center p-4">
-            <div
-              className="
-                w-full max-w-3xl transform overflow-hidden rounded-[8px] bg-white p-6 text-left
-                align-middle shadow-xl transition-all flex flex-col gap-6 max-h-[90vh]
-              "
-            >
-              {/* --- INÍCIO DO CONTEÚDO DO MODAL --- */}
-
-              {/* Bloco 1: Cabeçalho */}
-              <div className='flex justify-between items-start'>
-                <div>
+            <div className="w-full max-w-3xl transform overflow-hidden rounded-[8px] bg-white p-6 text-left shadow-xl transition-all flex flex-col gap-6 max-h-[95vh]">
+              <div className='flex justify-between items-start gap-4'>
+                <div className="flex items-center gap-4">
                   <h2 className="font-sans text-[20px] text-black font-bold">Revisão de Documentos</h2>
-                  <p className="font-sans text-[13px] text-[#4A5565]">
-                    Submissão de {auditoria.nomeEmpresa} - {formattedDate}
-                  </p>
+                  {/* O Chip só aparece se o status não for 'aguardando' */}
+                  {auditoria.status !== 'aguardando' && <Chip status={auditoria.status} />}
                 </div>
                 <button onClick={handleClose} className="p-1 rounded-full hover:bg-gray-100">
                   <X size={20} className='text-[#0A0A0A]' />
                 </button>
               </div>
-
-              {/* Bloco 2: Lógica de Troca de Tela */}
-              {isReproving ? (
-                <div className="flex flex-col rounded-[8px] border border-[#D1D5DC] gap-3 p-4 bg-white">
+              
+              
+              {auditoria.status === 'aguardando' && (
+                isReproving ? (
+                  <div className="flex flex-col rounded-[8px] border border-[#D1D5DC] gap-3 p-4 bg-white">
                   <label htmlFor="motivo" className="font-sans text-[14px] font-semibold text-[#101828]">Motivo da Reprovação</label>
                   <textarea
                     id="motivo"
@@ -61,68 +98,48 @@ export default function ModalRevisao({ isOpen, onClose, auditoria }: ModalRevisa
                     className="w-full rounded-[8px] border border-[#D1D5DC] shadow-sm text-[#858585] focus:border-blue-500 focus:ring-blue-500 sm:text-sm p-2"
                     placeholder="Descreva o motivo da reprovação dos documentos..."
                   />
-                </div>
-              ) : (
-                <>
-                  <div className='flex gap-3 p-4 bg-[#F9FAFB] rounded-[6px]'>
-                    <div className='flex flex-col gap-1.5 items-start w-1/2'>
-                      <h3 className='font-sans text-[14px] font-semibold text-[#101828]'>Detalhes da Doação</h3>
-                      <div className='text-left'>
-                        <p className='font-sans text-[14px] font-normal text-[#0A0A0A]'><span className="font-semibold">Empresa:</span> {auditoria.nomeEmpresa}</p>
-                        <p className='font-sans text-[14px] font-normal text-[#0A0A0A]'><span className="font-semibold">Email:</span> {auditoria.emailEmpresa}</p>
-                        <p className='font-sans text-[14px] font-normal text-[#0A0A0A]'><span className="font-semibold">ONG Beneficiada:</span> {auditoria.nomeONG}</p>
-                      </div>
-                    </div>
-                    <div className='flex flex-col gap-1.5 items-start w-1/2'>
-                      <h3 className='font-sans text-[14px] font-semibold text-[#101828]'>Informações da Doação</h3>
-                      <div className='text-left'>
-                        <p className='font-sans text-[14px] font-normal text-[#0A0A0A]'><span className="font-semibold">Ação:</span> {auditoria.acao || 'Não informado'}</p>
-                        <p className='font-sans text-[14px] font-normal text-[#0A0A0A]'><span className="font-semibold">Tipo:</span> {auditoria.tipoDoacao}</p>
-                        <p className='font-sans text-[14px] font-normal text-[#0A0A0A]'><span className="font-semibold">Valor/Quantidade:</span> {auditoria.valorDoacao}</p>
-                      </div>
-                    </div>
                   </div>
-
-                  <div className='flex flex-col gap-4 flex-1 min-h-0'>
-                    <h4 className='font-sans text-[16px] font-semibold text-[#101828]'>Documentos Anexados ({auditoria.documentos.length})</h4>
-                    <div className="flex flex-col gap-2.5 overflow-y-auto pr-6">
-                      {auditoria.documentos.map((doc) => (
-                        <div key={doc.id} className="flex justify-between items-center p-4 border border-[#E5E7EB] rounded-[8px] bg-white hover:bg-[#F9FAFB] transition-colors duration-200 gap-4">
-                          <div className="flex items-center gap-3 text-left">
-                            <div className='flex-shrink-0 flex items-center justify-center w-[34px] h-[34px] bg-[#EFF6FF] rounded-[4px]'><File size={20} className='text-[#1474FF]' /></div>
-                            <div>
-                              <p className="font-sans text-[#101828] text-[14px] font-semibold">{doc.nome}</p>
-                              <p className="font-sans text-[#6A7282] text-[12px] font-normal">
-                                {doc.tipo} • Enviado em {format(new Date(doc.dataEnvio), 'dd/MM/yyyy')}
-                              </p>
-                            </div>
-                          </div>
-                          <a href={doc.url} download={doc.nome} target="_blank" rel="noopener noreferrer" className="inline-flex items-center justify-center px-3 py-1.5 rounded-md font-semibold text-xs transition-colors bg-white text-gray-800 border border-gray-300 hover:bg-gray-100 flex-shrink-0">
-                            <Download size={14} className="mr-2" /> <span>Baixar</span>
-                          </a>
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-                </>
+                ) : (
+                  renderDetailsAndDocuments()
+                )
               )}
 
-              {/* Bloco 3: Rodapé com os botões de ação */}
-              <div className="flex justify-end gap-4  pt-6">
-                {isReproving ? (
-                  <>
-                    <Button variant="secondary" className="flex-1" onClick={() => setIsReproving(false)}>Voltar</Button>
-                    <Button variant="primary" className="flex-1" onClick={handleClose}>Reprovar e notificar</Button>
-                  </>
-                ) : (
-                  <>
-                    <Button variant="secondary" className="flex-1" onClick={() => setIsReproving(true)}>Reprovar</Button>
-                    <Button variant="primary" className="flex-1" onClick={handleClose}>Aprovar e notificar</Button>
-                  </>
-                )}
-              </div>
+              {auditoria.status === 'reprovada' && (
+                <div className="flex flex-col overflow-y-auto gap-6">
+                   <div className="flex flex-col gap-2 p-4 bg-red-50 border border-red-200 rounded-lg">
+                    <h4 className="font-sans text-[14px] font-semibold text-red-800 flex items-center gap-2"><XCircle size={16}/> Motivo da Reprovação</h4>
+                    <p className="font-sans text-sm text-red-700">{auditoria.motivoReprovacao || 'Nenhum motivo foi fornecido.'}</p>
+                   </div>
+                   {renderDetailsAndDocuments()}
+                </div>
+              )}
 
-              {/* --- FIM DO CONTEÚDO DO MODAL --- */}
+              {auditoria.status === 'aprovada' && (
+                <div className="flex flex-col overflow-y-auto gap-6">
+                  <div className="flex flex-col gap-2 p-4 bg-green-50 border border-green-200 rounded-lg">
+                    <h4 className="font-sans text-[14px] font-semibold text-green-800 flex items-center gap-2"><CheckCircle2 size={16}/> Documentação Aprovada</h4>
+                    <p className="font-sans text-sm text-green-700">Todos os documentos foram verificados e aprovados com sucesso.</p>
+                  </div>
+                  {renderDetailsAndDocuments()}
+                </div>
+              )}
+
+              {/* O rodapé só aparece se o status for 'aguardando' */}
+              {auditoria.status === 'aguardando' && (
+                <div className="flex justify-end gap-4 border-t border-gray-200 pt-6">
+                  {isReproving ? (
+                    <>
+                      <Button variant="secondary" className="flex-1" onClick={() => setIsReproving(false)}>Voltar</Button>
+                      <Button variant="primary" className="flex-1" onClick={handleClose}>Reprovar e notificar</Button>
+                    </>
+                  ) : (
+                    <>
+                      <Button variant="secondary" className="flex-1" onClick={() => setIsReproving(true)}>Reprovar</Button>
+                      <Button variant="primary" className="flex-1" onClick={handleClose}>Aprovar e notificar</Button>
+                    </>
+                  )}
+                </div>
+              )}
             </div>
           </div>
         </div>

--- a/client/src/components/row-auditoria/index.tsx
+++ b/client/src/components/row-auditoria/index.tsx
@@ -22,6 +22,7 @@ export interface RowAuditoriaProps {
    onClick?: () => void;
    documentos: Documento[];
    acao: string;
+   motivoReprovacao?: string;
 }   
 
 export default function RowAuditoria(props: RowAuditoriaProps) {
@@ -42,20 +43,19 @@ export default function RowAuditoria(props: RowAuditoriaProps) {
         <div className='w-[146px] flex justify-start'>
             <Chip status={props.status} />
         </div>
-        <div className='w-auto'>
+        <div className='w-[125px]'>
             <Button 
                 variant="secondary" 
                 onClick={(event) => {
-                    // Impede que o clique no botão também acione o clique da linha inteira
+                    
                     event.stopPropagation();
 
-                    // Chama a função que veio das props, se ela existir
                     if (props.onClick) {
                         props.onClick();
                     }
                 }}
             >
-                Revisar
+                {props.status === 'aguardando' ? 'Revisar' : 'Ver Detalhes'}
             </Button>
         </div>
     </div>


### PR DESCRIPTION
Refatoração do ModalRevisao: O componente agora renderiza condicionalmente uma de três variações com base no status da auditoria:
- Aguardando: Mantém o modal interativo para aprovar ou reprovar.
- Aprovada: Exibe um novo modal de visualização somente leitura.
- Reprovada: Exibe um novo modal de visualização que inclui o motivo da reprovação.
- Rodapé Condicional: O rodapé com os botões de ação ("Aprovar", "Reprovar") agora é exibido apenas para auditorias com status "Aguardando".
- CTA Dinâmico: O botão na linha da tabela (RowAuditoria) foi atualizado para exibir "Revisar" ou "Ver Detalhes", dependendo do status do item.